### PR TITLE
Use new style classes

### DIFF
--- a/datefinder.py
+++ b/datefinder.py
@@ -4,7 +4,7 @@ import regex as re
 from dateutil import tz
 
 
-class DateFinder():
+class DateFinder(object):
     """
     Locates dates in a text
     """


### PR DESCRIPTION
In Python 2, old style classes are still the default. Subclassing
``object`` uses new style classes instead. This ensures that ``super``
can be used when subclassing ``DateFinder`` (among other things).