### PR TITLE
Replace dateparser

### DIFF
--- a/datefinder.py
+++ b/datefinder.py
@@ -1,7 +1,7 @@
 import copy
 import dateparser
 import regex as re
-from dateutil import tz
+from dateutil import tz, parser
 
 
 class DateFinder(object):
@@ -202,7 +202,8 @@ class DateFinder(object):
         if len(date_string) < 3:
             return None
 
-        as_dt = dateparser.parse(date_string)
+        # as_dt = dateparser.parse(date_string)
+        as_dt = parser.parse(date_string)
         if tz_string:
             as_dt = self._add_tzinfo(as_dt, tz_string)
         return as_dt

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['dateparser', 'regex', 'python-dateutil', 'pytz'],
+    install_requires=['regex', 'python-dateutil', 'pytz'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['dateparser', 'regex', 'python-dateutil'],
+    install_requires=['dateparser', 'regex', 'python-dateutil', 'pytz'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/setup.py
+++ b/setup.py
@@ -89,8 +89,8 @@ setup(
     # for example:
     # $ pip install -e .[dev,test]
     extras_require={
-        'dev': ['pytest>=2.8.5', 'mock', 'pytz>=2015.7', 'dateparser==0.3.2'],
-        'test': ['pytest>=2.8.5', 'mock', 'pytz>=2015.7', 'dateparser==0.3.2'],
+        'dev': ['pytest>=2.8.5', 'mock', 'pytz>=2015.7'],
+        'test': ['pytest>=2.8.5', 'mock', 'pytz>=2015.7'],
     },
 
     # If there are data files included in your packages that need to be

--- a/tests/test_dateparser_example.py
+++ b/tests/test_dateparser_example.py
@@ -1,36 +1,36 @@
-import re
-import pytz
-from datetime import datetime
-import dateparser
-import pytest
+# import re
+# import pytz
+# from datetime import datetime
+# import dateparser
+# import pytest
 
-def expected_tz_conversion(datetime_obj, pytz_tzinfo_offset):
-    # keep the day and time, just give it tzinfo
-    return pytz_tzinfo_offset.localize(datetime_obj)
+# def expected_tz_conversion(datetime_obj, pytz_tzinfo_offset):
+#     # keep the day and time, just give it tzinfo
+#     return pytz_tzinfo_offset.localize(datetime_obj)
 
-@pytest.mark.parametrize('date_string, dateparser_expected_datetime, expected_datetime',[
-    [
-    '13/03/2014 MST',
-    datetime(2014, 3, 13, 7, 0), # assumes your /etc/localtime -> /usr/share/zoneinfo/America/Los_Angeles
-    datetime(2014, 3, 13, 0, 0).replace(tzinfo=pytz.timezone('MST'))
-    ]
-])
-def test_dateparser_and_two_alternatives(date_string, dateparser_expected_datetime, expected_datetime):
-    '''
-    parsing a date string such as "13/03/2014 MST" has many potential meanings
-    '''
+# @pytest.mark.parametrize('date_string, dateparser_expected_datetime, expected_datetime',[
+#     [
+#     '13/03/2014 MST',
+#     datetime(2014, 3, 13, 7, 0), # assumes your /etc/localtime -> /usr/share/zoneinfo/America/Los_Angeles
+#     datetime(2014, 3, 13, 0, 0).replace(tzinfo=pytz.timezone('MST'))
+#     ]
+# ])
+# def test_dateparser_and_two_alternatives(date_string, dateparser_expected_datetime, expected_datetime):
+#     '''
+#     parsing a date string such as "13/03/2014 MST" has many potential meanings
+#     '''
 
-    # the original default dateparser interpretation was to do a tzinfo shift plus a local conversion
-    # that changed in version 3.2 recently to do a UTC shift
-    # https://github.com/scrapinghub/dateparser/commit/6c6b3d93ac267901cbaaef534e2eb5c7d8c7deb8#diff-620d77b1f1bb42b71cf2181c8b7ce193L183
-    datetime_obj = dateparser.parse(date_string)
-    assert datetime_obj == dateparser_expected_datetime
+#     # the original default dateparser interpretation was to do a tzinfo shift plus a local conversion
+#     # that changed in version 3.2 recently to do a UTC shift
+#     # https://github.com/scrapinghub/dateparser/commit/6c6b3d93ac267901cbaaef534e2eb5c7d8c7deb8#diff-620d77b1f1bb42b71cf2181c8b7ce193L183
+#     datetime_obj = dateparser.parse(date_string)
+#     assert datetime_obj == dateparser_expected_datetime
 
-    # a more straightforward expectation might be to keep the day and time the same
-    # and just add the tzinfo to the datetime object if it is found
-    date_string_only, tzinfo_string = re.findall(r'[0-9\/]+',date_string)[0], re.findall(r'[a-zA-Z]+',date_string)[0]
-    datetime_obj = dateparser.parse(date_string_only)
-    assert expected_tz_conversion(datetime_obj, pytz.timezone(tzinfo_string)) == expected_datetime
+#     # a more straightforward expectation might be to keep the day and time the same
+#     # and just add the tzinfo to the datetime object if it is found
+#     date_string_only, tzinfo_string = re.findall(r'[0-9\/]+',date_string)[0], re.findall(r'[a-zA-Z]+',date_string)[0]
+#     datetime_obj = dateparser.parse(date_string_only)
+#     assert expected_tz_conversion(datetime_obj, pytz.timezone(tzinfo_string)) == expected_datetime
 
 
 

--- a/tests/test_dateparser_with_tzstring_auto_conversions.py
+++ b/tests/test_dateparser_with_tzstring_auto_conversions.py
@@ -1,15 +1,15 @@
-import re
-import pytz
-from datetime import datetime
-import dateparser
-from dateparser.timezone_parser import (
-    _tz_offsets,
-    local_tz_offset as my_local_os_tzoffset
-)
-import logging, sys
-logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
-logger = logging.getLogger(__name__)
-import pytest
+# import re
+# import pytz
+# from datetime import datetime
+# import dateparser
+# from dateparser.timezone_parser import (
+#     _tz_offsets,
+#     local_tz_offset as my_local_os_tzoffset
+# )
+# import logging, sys
+# logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+# logger = logging.getLogger(__name__)
+# import pytest
 
 
 # @pytest.mark.parametrize('date_string, expected_datetime',[
@@ -47,41 +47,41 @@ import pytest
 
 
 
-def expected_tz_conversion(datetime_obj, pytz_tzinfo_offset):
-    # keep the day and time, just give it tzinfo
-    return pytz_tzinfo_offset.localize(datetime_obj)
+# def expected_tz_conversion(datetime_obj, pytz_tzinfo_offset):
+#     # keep the day and time, just give it tzinfo
+#     return pytz_tzinfo_offset.localize(datetime_obj)
 
-@pytest.mark.parametrize('date_string, expected_datetime',[
-    ['13/03/2014 MST', datetime(2014, 3, 13, 0, 0).replace(tzinfo=pytz.timezone('MST')),]
-])
-def test_parse_with_expected_conversion(date_string, expected_datetime):
-    '''
-    parsing a date string such as "13/03/2014 MST" has many potential meanings.
-    one reasonable expectation would be to keep the day and time the same
-    and just add the tzinfo to the datetime object
-    '''
-    date_string, tzinfo_string = re.findall(r'[0-9\/]+',date_string)[0], re.findall(r'[a-zA-Z]+',date_string)[0]
-    datetime_obj = dateparser.parse(date_string)
-    assert expected_tz_conversion(datetime_obj, pytz.timezone(tzinfo_string)) == expected_datetime
-
-
+# @pytest.mark.parametrize('date_string, expected_datetime',[
+#     ['13/03/2014 MST', datetime(2014, 3, 13, 0, 0).replace(tzinfo=pytz.timezone('MST')),]
+# ])
+# def test_parse_with_expected_conversion(date_string, expected_datetime):
+#     '''
+#     parsing a date string such as "13/03/2014 MST" has many potential meanings.
+#     one reasonable expectation would be to keep the day and time the same
+#     and just add the tzinfo to the datetime object
+#     '''
+#     date_string, tzinfo_string = re.findall(r'[0-9\/]+',date_string)[0], re.findall(r'[a-zA-Z]+',date_string)[0]
+#     datetime_obj = dateparser.parse(date_string)
+#     assert expected_tz_conversion(datetime_obj, pytz.timezone(tzinfo_string)) == expected_datetime
 
 
-def another_expected_tz_conversion(datetime_obj, pytz_tzinfo_offset):
-    # use the subtraction operator to calc the tzinfo offset
-    datetime_obj_as_gmt = pytz.timezone('GMT').localize(datetime_obj)
-    return datetime_obj_as_gmt.astimezone(pytz_tzinfo_offset)
 
-@pytest.mark.parametrize('date_string, expected_datetime',[
-    ['13/03/2014 MST', datetime(2014, 3, 12, 17, 0).replace(tzinfo=pytz.timezone('MST')),]
-])
-def test_parse_with_another_expected_conversion(date_string, expected_datetime):
-    '''
-    parsing a date string such as "13/03/2014 MST" has many potential meanings.
-    another reasonable expectation would be to calculate only the tzinfo offset
-    '''
-    date_string, tzinfo_string = re.findall(r'[0-9\/]+',date_string)[0], re.findall(r'[a-zA-Z]+',date_string)[0]
-    datetime_obj = dateparser.parse(date_string)
-    assert another_expected_tz_conversion(datetime_obj, pytz.timezone(tzinfo_string)) == expected_datetime
+
+# def another_expected_tz_conversion(datetime_obj, pytz_tzinfo_offset):
+#     # use the subtraction operator to calc the tzinfo offset
+#     datetime_obj_as_gmt = pytz.timezone('GMT').localize(datetime_obj)
+#     return datetime_obj_as_gmt.astimezone(pytz_tzinfo_offset)
+
+# @pytest.mark.parametrize('date_string, expected_datetime',[
+#     ['13/03/2014 MST', datetime(2014, 3, 12, 17, 0).replace(tzinfo=pytz.timezone('MST')),]
+# ])
+# def test_parse_with_another_expected_conversion(date_string, expected_datetime):
+#     '''
+#     parsing a date string such as "13/03/2014 MST" has many potential meanings.
+#     another reasonable expectation would be to calculate only the tzinfo offset
+#     '''
+#     date_string, tzinfo_string = re.findall(r'[0-9\/]+',date_string)[0], re.findall(r'[a-zA-Z]+',date_string)[0]
+#     datetime_obj = dateparser.parse(date_string)
+#     assert another_expected_tz_conversion(datetime_obj, pytz.timezone(tzinfo_string)) == expected_datetime
 
 

--- a/tests/test_find_dates.py
+++ b/tests/test_find_dates.py
@@ -1,6 +1,7 @@
 import pytest
 import datefinder
 from datetime import datetime
+import pytz
 import sys
 import logging
 logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
@@ -30,7 +31,7 @@ logger = logging.getLogger(__name__)
     # Numeric dates
     ('06-17-2014', datetime(2014, 6, 17)),
     ('13/03/2014', datetime(2014, 3, 13)),
-    ('2016-02-04T20:16:26+00:00', datetime(2016, 2, 4, 20, 16, 26))
+    ('2016-02-04T20:16:26+00:00', datetime(2016, 2, 4, 20, 16, 26, tzinfo=pytz.utc))
     #('11. 12. 2014, 08:45:39', datetime(2014, 11, 12, 8, 45, 39)),
 ])
 def test_find_date_strings(input_text, expected_date):

--- a/tests/test_parse_date_string.py
+++ b/tests/test_parse_date_string.py
@@ -1,6 +1,5 @@
 import pytest
 import datefinder
-import dateparser
 from dateutil import tz, parser
 from datetime import datetime
 try:
@@ -30,7 +29,7 @@ logger = logging.getLogger(__name__)
         { 'timezones': ['central'] },
         datetime(2014, 3, 13).replace(tzinfo=tz.gettz('CST'))
     ),
-    # assert dateparser.parse successfully
+    # assert dateutil.parse successfully
     # handles tz-naive date strings
     # and returns naive datetime objects
     (

--- a/tests/test_parse_date_string.py
+++ b/tests/test_parse_date_string.py
@@ -1,7 +1,7 @@
 import pytest
 import datefinder
 import dateparser
-from dateutil import tz
+from dateutil import tz, parser
 from datetime import datetime
 try:
     from unittest import mock
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
     ('Friday pAcific stanDard time',
     'friday',
     {'timezones':['pacific']},
-    dateparser.parse('friday').replace(tzinfo=tz.gettz('PST'))
+    parser.parse('friday').replace(tzinfo=tz.gettz('PST'))
     ),
     ('13/03/2014 Central Daylight Savings Time',
     '13/03/2014',
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 ])
 def test_parse_date_string_find_replace(date_string, expected_parse_arg, expected_captures, expected_date):
     dt = datefinder.DateFinder()
-    with mock.patch.object(dateparser, 'parse', wraps=dateparser.parse) as spy:
+    with mock.patch.object(parser, 'parse', wraps=parser.parse) as spy:
         actual_datetime = dt.parse_date_string(date_string, expected_captures)
         spy.assert_called_with(expected_parse_arg)
         logger.debug("acutal={}  expected={}".format(actual_datetime, expected_date))

--- a/tests/test_parse_date_string.py
+++ b/tests/test_parse_date_string.py
@@ -12,44 +12,50 @@ logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
 logger = logging.getLogger(__name__)
 
 @pytest.mark.parametrize('date_string, expected_parse_arg, expected_captures, expected_date', [
-    ('due on Tuesday Jul 22, 2014 eastern standard time',
-    'tuesday jul 22 2014',
-    {'timezones': ['eastern']},
-    datetime(2014, 7, 22).replace(tzinfo=tz.gettz('EST'))
+    (
+        'due on Tuesday Jul 22, 2014 eastern standard time',
+        'tuesday jul 22 2014',
+        { 'timezones': ['eastern'] },
+        datetime(2014, 7, 22).replace(tzinfo=tz.gettz('EST'))
     ),
-    ('Friday pAcific stanDard time',
-    'friday',
-    {'timezones':['pacific']},
-    parser.parse('friday').replace(tzinfo=tz.gettz('PST'))
+    (
+        'Friday pAcific stanDard time',
+        'friday',
+        { 'timezones': ['pacific'] },
+        parser.parse('friday').replace(tzinfo=tz.gettz('PST'))
     ),
-    ('13/03/2014 Central Daylight Savings Time',
-    '13/03/2014',
-    {'timezones':['central']},
-    datetime(2014, 3, 13).replace(tzinfo=tz.gettz('CST'))
+    (
+        '13/03/2014 Central Daylight Savings Time',
+        '13/03/2014',
+        { 'timezones': ['central'] },
+        datetime(2014, 3, 13).replace(tzinfo=tz.gettz('CST'))
     ),
     # assert dateparser.parse successfully
     # handles tz-naive date strings
     # and returns naive datetime objects
-    (' on 12/24/2015 at 2pm ',
-    '12/24/2015 at 2pm',
-    {'timezones':[]},
-    datetime(2015, 12, 24, 14, 0)
+    (
+        ' on 12/24/2015 at 2pm ',
+        '12/24/2015 at 2pm',
+        { 'timezones': [] },
+        datetime(2015, 12, 24, 14, 0)
     ),
     # test a tz abbreviation that
     # dateutile.tz.gettz cannot find
     # and will return None for
-    (' on 11-20-2015 6pm CST ',
-     '11-20-2015 6pm',
-     {'timezones':['CST']},
-     datetime(2015, 11, 20, 18, 0)
+    (
+        ' on 11-20-2015 6pm CST ',
+        '11-20-2015 6pm',
+        { 'timezones': ['CST'] },
+        datetime(2015, 11, 20, 18, 0)
     ),
     # test a tz abbreviation that
     # dateutile.tz.gettz cannot find
     # and will return None for
-    (' on 11-20-2015 6am IRST ',
-     '11-20-2015 6am',
-     {'timezones':['IRST']},
-     datetime(2015, 11, 20, 6, 0)
+    (
+        ' on 11-20-2015 6am IRST ',
+        '11-20-2015 6am',
+        { 'timezones': ['IRST'] },
+        datetime(2015, 11, 20, 6, 0)
     )
 ])
 def test_parse_date_string_find_replace(date_string, expected_parse_arg, expected_captures, expected_date):


### PR DESCRIPTION
So it's decision time. Dateparser has added a new api argument that will not only NOT convert the datetime to the system timezone, but will also return a timezone aware datetime, by default converting to UTC. Dateparser is great because of it's multi-language usage and detection. However, we can't use thing so long as our regex capture only includes english tokens.

On the other hand, here is an example which hypothetically runs perfectly, just using dateutil. Either way we need to implement our own timezone mapping and disambiguation tool.