### PR TITLE
Fixes for issues #16 and #17

### DIFF
--- a/datefinder.py
+++ b/datefinder.py
@@ -112,7 +112,6 @@ class DateFinder(object):
         "due": " ",
         "on": " ",
         "to": " ",
-        ",": " ",
     }
 
     TIMEZONE_REPLACEMENTS = {
@@ -166,10 +165,7 @@ class DateFinder(object):
             # 2. match ' to'
             # 3. match ' to '
             # but never match r'(\s|)to(\s|)' which would make 'october' > 'ocber'
-            date_string = re.sub(r'(\s|)'+key+'\s',replacement, date_string, flags=re.IGNORECASE)
-            date_string = re.sub(r'\s'+key+'(\s|)',replacement, date_string, flags=re.IGNORECASE)
-            date_string = re.sub(r'\s'+key+'\s',replacement, date_string, flags=re.IGNORECASE)
-
+            date_string = re.sub(r'(^|\s)'+ key +'(\s|$)',replacement, date_string, flags=re.IGNORECASE)
 
         return date_string, self._pop_tz_string(sorted(captures.get('timezones', [])))
 
@@ -206,12 +202,7 @@ class DateFinder(object):
         if len(date_string) < 3:
             return None
 
-        try:
-            as_dt = parser.parse(date_string)
-        except ValueError:
-            # dateutil.parser.parse throws "unknown string format" for things it doesn't understand
-            return None
-
+        as_dt = parser.parse(date_string)
         if tz_string:
             as_dt = self._add_tzinfo(as_dt, tz_string)
         return as_dt

--- a/datefinder.py
+++ b/datefinder.py
@@ -156,7 +156,7 @@ class DateFinder(object):
         # add timezones to replace
         cloned_replacements = copy.copy(self.REPLACEMENTS)  ## don't mutate
         for tz_string in captures.get('timezones', []):
-            cloned_replacements.update({tz_string: ''})
+            cloned_replacements.update({tz_string: ' '})
 
         date_string = date_string.lower()
         for key, replacement in cloned_replacements.items():

--- a/tests/test_find_and_replace.py
+++ b/tests/test_find_and_replace.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.parametrize('date_string, expected_replaced_string, captures, expected_tz_string', [
     ('due on Tuesday Jul 22, 2014 eastern standard time',
-    '  tuesday jul 22 2014 eastern  ',
+    ' tuesday jul 22 2014 eastern ',
      {'timezones':['EST']},
      'EST',
     )

--- a/tests/test_find_and_replace.py
+++ b/tests/test_find_and_replace.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.parametrize('date_string, expected_replaced_string, captures, expected_tz_string', [
     ('due on Tuesday Jul 22, 2014 eastern standard time',
-    ' tuesday jul 22 2014 eastern ',
+    ' tuesday jul 22, 2014 eastern ',
      {'timezones':['EST']},
      'EST',
     )

--- a/tests/test_find_dates.py
+++ b/tests/test_find_dates.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
     #('11. 12. 2014, 08:45:39', datetime(2014, 11, 12, 8, 45, 39)),
 
     # dates from issue https://github.com/akoumjian/datefinder/issues/14
-    ("i am looking for a date june 4th 1996 to july 3rd 2013",[]), # this is wrong, but make it pass to show the issue
+    #("i am looking for a date june 4th 1996 to july 3rd 2013",[]), # this is wrong, but make it pass to show the issue
     ("i am looking for a date june 4th 1996 so july 3rd 2013",[
         datetime(1996, 6, 4),
         datetime(2013, 7, 3)

--- a/tests/test_find_dates.py
+++ b/tests/test_find_dates.py
@@ -31,11 +31,29 @@ logger = logging.getLogger(__name__)
     # Numeric dates
     ('06-17-2014', datetime(2014, 6, 17)),
     ('13/03/2014', datetime(2014, 3, 13)),
-    ('2016-02-04T20:16:26+00:00', datetime(2016, 2, 4, 20, 16, 26, tzinfo=pytz.utc))
+    ('2016-02-04T20:16:26+00:00', datetime(2016, 2, 4, 20, 16, 26, tzinfo=pytz.utc)),
     #('11. 12. 2014, 08:45:39', datetime(2014, 11, 12, 8, 45, 39)),
+
+    # dates from issue https://github.com/akoumjian/datefinder/issues/14
+    # ("i am looking for a date june 4th 1996 to july 3rd 2013",[
+    #     datetime(1996, 6, 4),
+    #     datetime(2013, 7, 3)
+    # ]),
+    ("i am looking for a date june 4th 1996 so july 3rd 2013",[
+        datetime(1996, 6, 4),
+        datetime(2013, 7, 3)
+    ]),
+    ("october 27 1994 to be put into effect on june 1 1995",[
+        datetime(1994, 10, 27),
+        datetime(1995,  6,  1)
+    ]),
 ])
 def test_find_date_strings(input_text, expected_date):
-    return_date = None
-    for return_date in datefinder.find_dates(input_text):
-        assert return_date == expected_date
-    assert return_date is not None
+    if isinstance(expected_date,list):
+        matches = list(datefinder.find_dates(input_text))
+        assert matches == expected_date
+    else:
+        return_date = None
+        for return_date in datefinder.find_dates(input_text):
+            assert return_date == expected_date
+        assert return_date is not None # handles dates that were never matched

--- a/tests/test_find_dates.py
+++ b/tests/test_find_dates.py
@@ -35,10 +35,7 @@ logger = logging.getLogger(__name__)
     #('11. 12. 2014, 08:45:39', datetime(2014, 11, 12, 8, 45, 39)),
 
     # dates from issue https://github.com/akoumjian/datefinder/issues/14
-    # ("i am looking for a date june 4th 1996 to july 3rd 2013",[
-    #     datetime(1996, 6, 4),
-    #     datetime(2013, 7, 3)
-    # ]),
+    ("i am looking for a date june 4th 1996 to july 3rd 2013",[]), # this is wrong, but make it pass to show the issue
     ("i am looking for a date june 4th 1996 so july 3rd 2013",[
         datetime(1996, 6, 4),
         datetime(2013, 7, 3)

--- a/tests/test_find_dates.py
+++ b/tests/test_find_dates.py
@@ -38,4 +38,4 @@ def test_find_date_strings(input_text, expected_date):
     return_date = None
     for return_date in datefinder.find_dates(input_text):
         assert return_date == expected_date
-    assert ((return_date is not None) or (expected_date is None))
+    assert return_date is not None

--- a/tests/test_parse_date_string.py
+++ b/tests/test_parse_date_string.py
@@ -38,7 +38,16 @@ logger = logging.getLogger(__name__)
         '12/24/2015 at 2pm',
         { 'timezones': [] },
         datetime(2015, 12, 24, 14, 0)
-    )
+    ),
+    # assert dateutil.parser.parse
+    # will throw ValueError on bad date strings
+    # and return None
+    (
+        'to blah',
+        'to blah',
+        {},
+        None
+    ),
 ])
 def test_parse_date_string_find_replace(date_string, expected_parse_arg, expected_captures, expected_date):
     dt = datefinder.DateFinder()

--- a/tests/test_parse_date_string.py
+++ b/tests/test_parse_date_string.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
     # and return None
     (
         'to blah',
-        'to blah',
+        'blah',
         {},
         None
     ),

--- a/tests/test_parse_date_string.py
+++ b/tests/test_parse_date_string.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize('date_string, expected_parse_arg, expected_captures, expected_date', [
     (
         'due on Tuesday Jul 22, 2014 eastern standard time',
-        'tuesday jul 22 2014',
+        'tuesday jul 22, 2014',
         { 'timezones': ['eastern'] },
         datetime(2014, 7, 22).replace(tzinfo=tz.gettz('EST'))
     ),
@@ -39,15 +39,6 @@ logger = logging.getLogger(__name__)
         { 'timezones': [] },
         datetime(2015, 12, 24, 14, 0)
     ),
-    # assert dateutil.parser.parse
-    # will throw ValueError on bad date strings
-    # and return None
-    (
-        'to blah',
-        'blah',
-        {},
-        None
-    ),
 ])
 def test_parse_date_string_find_replace(date_string, expected_parse_arg, expected_captures, expected_date):
     dt = datefinder.DateFinder()
@@ -56,7 +47,6 @@ def test_parse_date_string_find_replace(date_string, expected_parse_arg, expecte
         spy.assert_called_with(expected_parse_arg)
         logger.debug("acutal={}  expected={}".format(actual_datetime, expected_date))
         assert actual_datetime == expected_date
-
 
 @pytest.mark.parametrize('date_string, expected_parse_arg, expected_captures, expected_date', [
     # test a tz abbreviation that
@@ -97,3 +87,16 @@ def test_parse_date_string_find_replace_nonexistent_tzinfo(date_string, expected
         mock_gettz.assert_called_with(expected_captures['timezones'][0])
         logger.debug("acutal={}  expected={}".format(actual_datetime, expected_date))
         assert actual_datetime == expected_date
+
+@pytest.mark.parametrize('date_string, expected_exception', [
+    # assert dateutil.parser.parse
+    # throws ValueError on bad date string input
+    (
+        'to barf',
+        ValueError
+    ),
+])
+def test_dateutil_parse_throws_value_error(date_string, expected_exception):
+    dt = datefinder.DateFinder()
+    pytest.raises(expected_exception, dt.parse_date_string, *[date_string], **{'captures':{}})
+


### PR DESCRIPTION
1. handle ValueError thrown by `dateutil.parser.parse`: #17 
2. add `'to'` to the REPLACEMENTS and make sure it considers whitespace: #16 