### PR TITLE
Fix for akoumjian/datefinder#37

### DIFF
--- a/datefinder.py
+++ b/datefinder.py
@@ -237,7 +237,6 @@ class DateFinder(object):
             months = captures.get('months')
             timezones = captures.get('timezones')
             delimiters = captures.get('delimiters')
-            time = captures.get('time)')
             time_periods = captures.get('time_periods')
             extra_tokens = captures.get('extra_tokens')
 

--- a/datefinder.py
+++ b/datefinder.py
@@ -41,6 +41,7 @@ class DateFinder(object):
             \:
             (?P<minutes>\d{{1,2}})
             (\:(?<seconds>\d{{1,2}}))?
+            ([\.\,](?<microseconds>\d{{1,6}}))?
             \s*
             (?P<time_periods>{time_periods})?
             \s*

--- a/tests/test_find_dates.py
+++ b/tests/test_find_dates.py
@@ -44,6 +44,10 @@ logger = logging.getLogger(__name__)
         datetime(1994, 10, 27),
         datetime(1995,  6,  1)
     ]),
+    # Z dates with and without millis, from https://github.com/akoumjian/datefinder/issues/37
+    ("2017-02-03T09:04:08.001Z", datetime(2017, 2, 3, 9, 4, 8, 1000, tzinfo=pytz.utc)),
+    ("2017-02-03T09:04:08.00123Z", datetime(2017, 2, 3, 9, 4, 8, 1230, tzinfo=pytz.utc)),
+    ("2017-02-03T09:04:08Z", datetime(2017, 2, 3, 9, 4, 8, tzinfo=pytz.utc)),
 ])
 def test_find_date_strings(input_text, expected_date):
     if isinstance(expected_date,list):
@@ -53,4 +57,4 @@ def test_find_date_strings(input_text, expected_date):
         return_date = None
         for return_date in datefinder.find_dates(input_text):
             assert return_date == expected_date
-        assert return_date is not None # handles dates that were never matched
+        assert return_date is not None, 'Did not find date for test line: "{}"'.format(input_text) # handles dates that were never matched

--- a/tests/test_find_dates.py
+++ b/tests/test_find_dates.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
     ]),
     # Z dates with and without millis, from https://github.com/akoumjian/datefinder/issues/37
     ("2017-02-03T09:04:08.001Z", datetime(2017, 2, 3, 9, 4, 8, 1000, tzinfo=pytz.utc)),
-    ("2017-02-03T09:04:08.00123Z", datetime(2017, 2, 3, 9, 4, 8, 1230, tzinfo=pytz.utc)),
+    ("2017-02-03T09:04:08,00123Z", datetime(2017, 2, 3, 9, 4, 8, 1230, tzinfo=pytz.utc)),
     ("2017-02-03T09:04:08Z", datetime(2017, 2, 3, 9, 4, 8, tzinfo=pytz.utc)),
 ])
 def test_find_date_strings(input_text, expected_date):


### PR DESCRIPTION
Fixes akoumjian/datefinder#37

This pull request has 4 commits:
  - (a5508ad) fixes bad detection of the ISO 8601 UTC "Z" character caused by the `_find_and_replace` method moving the Z char to lower case, and causind dateutils.parse to fail.
  - (e3d8407) Add support for microseconds detection in the TIME_PATTERN regex
  - (1ecfdb2) Cleanup one redundant and buggy line of code
  - (e6fdd1b) Corrected unit test for milliseconds with coma, not dot

The fix in a5508ad could be done differently, this can be debated.

IMPORTANT NOTE:
Before starting working on this, none of the tests for `tests/test_parse_date_string.py` were passing.
So, I started by adding unit tests in `tests/test_find_dates.py` and only ran py.test against that file, which are passing.