### PR TITLE
Simple range-finding patch based on nested regex

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,10 +38,6 @@ How to Use
 ----------
 
 
-.. automodule:: datefinder
-   :members: find_dates
-
-
 .. code-block:: python
 
     In [1]: string_with_dates = """

--- a/datefinder.py
+++ b/datefinder.py
@@ -20,7 +20,7 @@ class DateFinder(object):
     ## explicit north american timezones that get replaced
     NA_TIMEZONES_PATTERN = 'pacific|eastern|mountain|central'
     ALL_TIMEZONES_PATTERN = TIMEZONES_PATTERN + '|' + NA_TIMEZONES_PATTERN
-    DELIMITERS_PATTERN = '[/\:\-\,\s\_\+\@]+'
+    DELIMITERS_PATTERN = '[/\:\-\,\.\s\_\+\@]+'
     TIME_PERIOD_PATTERN = 'a\.m\.|am|p\.m\.|pm'
     ## can be in date strings but not recognized by dateutils
     EXTRA_TOKENS_PATTERN = 'due|by|on|during|standard|daylight|savings|time|date|dated|of|to|through|between|until|z|at|t'
@@ -278,6 +278,9 @@ class DateFinder(object):
                 delimiters = captures.get('delimiters')
                 time_periods = captures.get('time_periods')
                 extra_tokens = captures.get('extra_tokens')
+
+                if delimiters and match_str.endswith(delimiters[-1]):
+                    captures['delimiters'] = captures['delimiters'][:-1]
 
                 if strict:
                     complete = False

--- a/datefinder.py
+++ b/datefinder.py
@@ -23,7 +23,7 @@ class DateFinder(object):
     DELIMITERS_PATTERN = '[/\:\-\,\s\_\+\@]+'
     TIME_PERIOD_PATTERN = 'a\.m\.|am|p\.m\.|pm'
     ## can be in date strings but not recognized by dateutils
-    EXTRA_TOKENS_PATTERN = 'due|by|on|standard|daylight|savings|time|date|of|to|until|z|at|t'
+    EXTRA_TOKENS_PATTERN = 'due|by|on|during|standard|daylight|savings|time|date|dated|of|to|through|between|until|z|at|t'
 
     ## TODO: Get english numbers?
     ## http://www.rexegg.com/regex-trick-numbers-in-english.html
@@ -100,9 +100,21 @@ class DateFinder(object):
         extra_tokens=EXTRA_TOKENS_PATTERN
     )
 
+    RANGE_PATTERN = r"""
+    (
+        (
+            (?P<date_1>{date_pattern}){{1,}}
+            (to|through){{1,}}
+            (?P<date_2>{date_pattern}){{1,}}
+        ){{1,}}
+    )
+    """.format(date_pattern=DATES_PATTERN)
+
     DATE_REGEX = re.compile(DATES_PATTERN, re.IGNORECASE | re.MULTILINE | re.UNICODE | re.DOTALL | re.VERBOSE)
 
     TIME_REGEX = re.compile(TIME_PATTERN, re.IGNORECASE | re.MULTILINE | re.UNICODE | re.DOTALL | re.VERBOSE)
+
+    RANGE_REGEX = re.compile(RANGE_PATTERN, re.IGNORECASE | re.MULTILINE | re.UNICODE | re.DOTALL | re.VERBOSE)
 
     ## These tokens can be in original text but dateutil
     ## won't handle them without modification
@@ -230,41 +242,62 @@ class DateFinder(object):
         index: also return the indices of the date string in the text
         strict: Strict mode will only return dates sourced with day, month, and year
         """
+        # Begin by trying to match ranges
         for match in self.DATE_REGEX.finditer(text):
             match_str = match.group(0)
             indices = match.span(0)
 
-            ## Get individual group matches
-            captures = match.capturesdict()
-            time = captures.get('time')
-            digits = captures.get('digits')
-            digits_modifiers = captures.get('digits_modifiers')
-            days = captures.get('days')
-            months = captures.get('months')
-            timezones = captures.get('timezones')
-            delimiters = captures.get('delimiters')
-            time_periods = captures.get('time_periods')
-            extra_tokens = captures.get('extra_tokens')
+            # Check if we match a range too
+            found_range = False
+            range_strings = []
+            for range_match in self.RANGE_REGEX.finditer(match_str):
+                # Parse date 1 and date 2 recursively
+                range_captures = range_match.capturesdict()
+                date_1 = range_captures.get("date_1", [])
+                date_2 = range_captures.get("date_2", [])
 
-            if strict:
-                complete = False
-                ## 12-05-2015
-                if len(digits) == 3:
-                    complete = True
-                ## 19 February 2013 year 09:10
-                elif (len(months) == 1) and (len(digits) == 2):
-                    complete = True
+                for date_1_str in date_1:
+                    range_strings.extend(self.extract_date_strings(date_1_str, strict=strict))
 
-                if not complete:
-                    continue
+                for date_2_str in date_2:
+                    range_strings.extend(self.extract_date_strings(date_2_str, strict=strict))
 
-            ## sanitize date string
-            ## replace unhelpful whitespace characters with single whitespace
-            match_str = re.sub('[\n\t\s\xa0]+', ' ', match_str)
-            match_str = match_str.strip(self.STRIP_CHARS)
 
-            ## Save sanitized source string
-            yield match_str, indices, captures
+            for range_string in range_strings:
+                yield range_string
+
+            if not found_range:
+                ## Get individual group matches
+                captures = match.capturesdict()
+                time = captures.get('time')
+                digits = captures.get('digits')
+                digits_modifiers = captures.get('digits_modifiers')
+                days = captures.get('days')
+                months = captures.get('months')
+                timezones = captures.get('timezones')
+                delimiters = captures.get('delimiters')
+                time_periods = captures.get('time_periods')
+                extra_tokens = captures.get('extra_tokens')
+
+                if strict:
+                    complete = False
+                    ## 12-05-2015
+                    if len(digits) == 3:
+                        complete = True
+                        ## 19 February 2013 year 09:10
+                    elif (len(months) == 1) and (len(digits) == 2):
+                        complete = True
+                        
+                    if not complete:
+                        continue
+
+                ## sanitize date string
+                ## replace unhelpful whitespace characters with single whitespace
+                match_str = re.sub('[\n\t\s\xa0]+', ' ', match_str)
+                match_str = match_str.strip(self.STRIP_CHARS)
+
+                ## Save sanitized source string
+                yield match_str, indices, captures
 
 
 def find_dates(

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['regex==2020.7.14', 'python-dateutil>=2.4.2', 'pytz'],
+    install_requires=['regex==2020.11.13', 'python-dateutil>=2.4.2', 'pytz'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['regex==2017.9.23', 'python-dateutil>=2.4.2', 'pytz'],
+    install_requires=['regex==2020.7.14', 'python-dateutil>=2.4.2', 'pytz'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.6.1',
+    version='0.6.2',
 
     description='Extract datetime objects from strings',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -14,26 +14,32 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
-    long_description = f.read()
+try:
+    with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+        long_description = f.read()
+except Exception as e:
+    long_description = "LexPredict LexNLP: A swiss-army knife library built for working with real, unstructured legal text."
 
 setup(
-    name='datefinder',
+    name='datefinder-lexpredict',
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
     version='0.6.2',
 
-    description='Extract datetime objects from strings',
+    description='Extract datetime objects from strings (LexPredict fork)',
     long_description=long_description,
 
     # The project's main homepage.
-    url='https://github.com/akoumjian/datefinder',
+    url='https://github.com/LexPredict/datefinder',
 
     # Author details
-    author='Alec Koumjian',
-    author_email='akoumjian@gmail.com',
+    #author='Alec Koumjian',
+    #author_email='akoumjian@gmail.com',
+    author='ContraxSuite, LLC',
+    author_email='support@contraxsuite.com',
+
 
     # Choose your license
     license='MIT',

--- a/tests/test_find_dates.py
+++ b/tests/test_find_dates.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
     ('Fri, 12 Dec 2014 10:55:50', datetime(2014, 12, 12, 10, 55, 50)),
     #('20 Mar 2013 10h11', datetime(2013, 3, 20, 10, 11)),
     ('10:06am Dec 11, 2014', datetime(2014, 12, 11, 10, 6)),
+    ('May 5, 2010 to July 10, 2011', [datetime(2010, 5, 5), datetime(2011, 7, 10)]),
     #('19 February 2013 year 09:10', datetime(2013, 2, 19, 9, 10)),
 
     # Numeric dates


### PR DESCRIPTION
@akoumjian , we know that you've worked on issue #18 in the past and haven't found a solution you're happy with.  We have a similar use case to #18, #29, etc. and have been using the following modified approach to resolve it.  It is simple and English-specific, but has worked for us with thousands of real documents.

There are two considerations here:
* situations where both "ranges" and non-range dates exist, e.g., `"I left on January 1, 2017 and was gone from January 2, 2017 to January 31, 2017."`
* performance of two regex passes instead of one

You can see the desired behavior exhibited here:
```
>>> import datefinder
>>> datefinder.find_dates("I left on January 1, 2017 and was gone from January 2, 2017 to January 31, 2017.")
<generator object find_dates at 0x7f105867b4b0>
>>> list(datefinder.find_dates("I left on January 1, 2017 and was gone from January 2, 2017 to January 31, 2017."))
[datetime.datetime(2017, 1, 1, 0, 0), datetime.datetime(2017, 1, 2, 0, 0), datetime.datetime(2017, 1, 31, 0, 0)]
```

One option is to allow the user to enable/disable the range search.  Another is to keep track of dates found in the range regex and exclude them from the non-range regex.  A third would be to modify the single regex to optionally match one or more dates separated with these range delimiters.  

For a variety of reasons, this is the one we settled on, and we thought that we'd share it in case it helps you or others.