### PR TITLE
change regex version to >= 2016.01.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['regex==2016.01.10', 'python-dateutil>=2.4.2', 'pytz'],
+    install_requires=['regex>=2016.01.10,<2017.12.1', 'python-dateutil>=2.4.2', 'pytz'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
regex version 2016.01.10 is not compatible with other python packages, so changing package version will helpful and it will not overwrite regex version to 2016.01.10 when install of datefinder. Thanks !