### PR TITLE
replace Regex range splitting for python logic

### DIFF
--- a/datefinder/constants.py
+++ b/datefinder/constants.py
@@ -106,7 +106,7 @@ DATES_PATTERN = """
         (?P<extra_tokens>{extra_tokens})
     ## We need at least three items to match for minimal datetime parsing
     ## ie 10pm
-    ){{3,}}
+    ){{1,1}}
 )
 """
 
@@ -124,15 +124,10 @@ DATES_PATTERN = DATES_PATTERN.format(
     extra_tokens=EXTRA_TOKENS_PATTERN,
 )
 
-RANGE_PATTERN = r"""
-(?:
-    (?P<dt1>{date_pattern})
-    [\s]?(to|through)[\s]?
-    (?P<dt2>{date_pattern})
-)
-""".format(
-    date_pattern=DATES_PATTERN
-)
+ALL_GROUPS = ['time', 'years', 'numbers', 'digits', 'digits_suffixes', 'days',
+              'months', 'delimiters', 'positionnal_tokens', 'extra_tokens',
+              'undelimited_stamps', 'hours', 'minutes', 'seconds', 'microseconds',
+              'time_periods', 'timezones']
 
 DATE_REGEX = re.compile(
     DATES_PATTERN, re.IGNORECASE | re.MULTILINE | re.UNICODE | re.DOTALL | re.VERBOSE
@@ -140,10 +135,6 @@ DATE_REGEX = re.compile(
 
 TIME_REGEX = re.compile(
     TIME_PATTERN, re.IGNORECASE | re.MULTILINE | re.UNICODE | re.DOTALL | re.VERBOSE
-)
-
-RANGE_REGEX = re.compile(
-    RANGE_PATTERN, re.IGNORECASE | re.MULTILINE | re.UNICODE | re.DOTALL | re.VERBOSE
 )
 
 ## These tokens can be in original text but dateutil
@@ -171,3 +162,8 @@ TIMEZONE_REPLACEMENTS = {
 ## Characters that can be removed from ends of matched strings
 STRIP_CHARS = " \n\t:-.,_"
 
+# split ranges
+RANGE_SPLIT_PATTERN = r'\Wto\W|\Wthrough\W'
+
+RANGE_SPLIT_REGEX =  re.compile(RANGE_SPLIT_PATTERN,
+    re.IGNORECASE | re.MULTILINE | re.UNICODE | re.DOTALL)

--- a/datefinder/date_fragment.py
+++ b/datefinder/date_fragment.py
@@ -1,0 +1,22 @@
+from typing import Dict, List
+
+
+'''
+This class describes big chunks of text that may contain date strings
+Each chunk includes of one of more tokens
+Each token is build upon DATE_REGEX matches
+'''
+
+
+class DateFragment:
+    def __init__(self):
+        self.match_str = ''
+        self.indices = (0, 0)
+        self.captures = {}  # type:Dict[str, List[str]]
+
+    def __repr__(self):
+        str_capt = ', '.join(['"{}": [{}]'.format(c, self.captures[c]) for c in self.captures])
+        return '{} [{}, {}]\nCaptures: {}'.format(self.match_str, self.indices[0], self.indices[1], str_capt)
+
+    def get_captures_count(self):
+        return sum([len(self.captures[m]) for m in self.captures])

--- a/tests/test_extract_date_strings.py
+++ b/tests/test_extract_date_strings.py
@@ -20,6 +20,9 @@ def test_extract_date_strings(date_string, expected_match_date_string):
         assert actual_date_string == expected_match_date_string
         assert len(captures.get('timezones',[])) > 0
 
+# TODO: 'May 20th 2015 is nowhere near the other date' was not recognized as
+# a date string: this string produced no result, but there was no error
+# because for-loop didn't make this iteration (no result in dt.extract_date_strings)
 
 @pytest.mark.parametrize('date_string, expected_match_date_string', [
     ['the Friday after next Tuesday the 20th', ''], # no matches


### PR DESCRIPTION
Dear Alec,

I appreciate sharing your code. It does what it is designed for. But sometimes while using DateFinder I faced Regex **catastrophic backtracking problem**. Especially while parsing "tables" in plain text like this: [codepile sample](https://www.codepile.net/pile/gQwgz8QE).

The root of the problem was in **RANGE_REGEX**. I have replaced this logic by simply splitting the source text by "to" / "through" keywords. I've also simplified the main (DATE_REGEX) regex a bit.

The plain text I referenced above took about 48s to be parsed. Now, after this code update, this piece of text takes only 0.007s.

Could you consider applying my changes or, at least, changing the logic of splitting date ranges (RANGE_REGEX)?

Thank you in advance!