### PR TITLE
Add is_day_first parameter

### DIFF
--- a/datefinder/__init__.py
+++ b/datefinder/__init__.py
@@ -255,7 +255,7 @@ class DateFinder(object):
         
         if frag.get_captures_count() >= MIN_MATCHES:  # frag.matches
             fragments.append(frag)
-        elif any([int(year) in POSSIBLE_YEARS for year in frag.captures["years"]]):
+        elif any([int(year) in POSSIBLE_YEARS for year in frag.captures.get("years", [])]):
             fragments.append(frag)
 
         for frag in fragments:

--- a/datefinder/constants.py
+++ b/datefinder/constants.py
@@ -154,6 +154,15 @@ REPLACEMENTS = {
     "day": " ",
 }
 
+PREPROCESSING_REPLACEMENT = {
+    "(?=\s|^)q1(?=(\s|\d{2}))": "31-03",
+    "(?=\s|^)q2(?=(\s|\d{2}))": "30-06",
+    "(?=\s|^)q3(?=(\s|\d{2}))": "30-09",
+    "(?=\s|^)q4(?=(\s|\d{2}))": "31-12",
+    "(?=\s|^)ye(?=(\s|\d{2}))": "31-12",
+}
+
+
 TIMEZONE_REPLACEMENTS = {
     "pacific": "PST",
     "eastern": "EST",

--- a/datefinder/constants.py
+++ b/datefinder/constants.py
@@ -1,4 +1,6 @@
 import regex as re
+import datetime
+
 
 NUMBERS_PATTERN = r"first|second|third|fourth|fifth|sixth|seventh|eighth|nineth|tenth"
 POSITIONNAL_TOKENS = r"next|last"
@@ -167,3 +169,6 @@ RANGE_SPLIT_PATTERN = r'\Wto\W|\Wthrough\W'
 
 RANGE_SPLIT_REGEX =  re.compile(RANGE_SPLIT_PATTERN,
     re.IGNORECASE | re.MULTILINE | re.UNICODE | re.DOTALL)
+
+CURRENT_YEAR = datetime.datetime.now().year
+POSSIBLE_YEARS = list(range(CURRENT_YEAR-10, CURRENT_YEAR+10))

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="0.7.1",
+    version="0.7.2",
     description="Extract datetime objects from strings",
     long_description=long_description,
     # The project's main homepage.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="0.7.0",
+    version="0.7.1",
     description="Extract datetime objects from strings",
     long_description=long_description,
     # The project's main homepage.

--- a/tests/test_extract_date_strings.py
+++ b/tests/test_extract_date_strings.py
@@ -28,7 +28,7 @@ def test_extract_date_strings(date_string, expected_match_date_string):
     ['the Friday after next Tuesday the 20th', ''], # no matches
     ['This Tuesday March 2015 in the evening', ''], # no matches
     ['They said it was on 01-03-2015', 'on 01-03-2015'], # 3 digits strict match
-    ['May 20th 2015 is nowhere near the other date', 'May 20 2015'], # one month two digit match
+    ['May 20th 2015 is nowhere near the other date', 'May 20th 2015'], # one month two digit match
 ])
 def test_extract_date_strings_with_strict_option(date_string, expected_match_date_string):
     """


### PR DESCRIPTION
Add is_day_first for dateutil parser so we have the option whether to interpret the first value in an ambiguous 3-integer date (e.g. 01/05/09) as the day (True) or month (False)