### PR TITLE
added conda installation option to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,10 @@ datefinder - extract dates from text
     :target: https://gitter.im/datefinder/Lobby
     :alt: gitter chat
 
-.. image:: https://anaconda.org/conda-forge/datefinder/badges/version.svg
+.. image:: https://img.shields.io/conda/v/conda-forge/datefinder?color=blue&logo=anaconda
     :target: https://anaconda.org/conda-forge/datefinder
     :alt: conda version
+
 
 A python module for locating dates inside text. Use this package to extract all sorts 
 of date like strings from a document and turn them into datetime objects.

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,9 @@ datefinder - extract dates from text
     :target: https://gitter.im/datefinder/Lobby
     :alt: gitter chat
 
+.. image:: https://anaconda.org/conda-forge/datefinder/badges/version.svg
+    :target: https://anaconda.org/conda-forge/datefinder
+    :alt: conda version
 
 A python module for locating dates inside text. Use this package to extract all sorts 
 of date like strings from a document and turn them into datetime objects.

--- a/README.rst
+++ b/README.rst
@@ -28,10 +28,17 @@ This module finds the likely datetime strings and then uses
 Installation
 ------------
 
+**With pip**
+
 .. code-block:: sh
 
     pip install datefinder
 
+**With conda**
+
+.. code-block:: sh
+
+    conda install -c conda-forge datefinder
 
 How to Use
 ----------

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,14 @@ How to Use
     2005-01-15 00:00:00
 
 
+Demo
+----
+
+-  🎞️ `Video demo`_ by Calmcode.io. :star: 
+
+.. _Video demo: https://calmcode.io/shorts/datefinder.py.html
+
+
 Support
 -------
 


### PR DESCRIPTION
The repository currently  only points to using `pip` for installation. There's no mention of `conda` (Anaconda/Miniconda) installation command yet. However, the following is available:

```sh
conda install -c conda-forge datefinder
```

This was added to the readme.