### PR TITLE
fix: skip relative offsets that overflow chrono/Python years

### DIFF
--- a/rust/datefinder-kernel/src/lib.rs
+++ b/rust/datefinder-kernel/src/lib.rs
@@ -1506,7 +1506,7 @@ fn parse_raw(
                 grain: "day",
                 value: RawValue::Relative {
                     resolved_datetime: resolved.to_rfc3339(),
-                    delta_seconds: days * 86_400,
+                    delta_seconds,
                     anchor: "reference".to_string(),
                 },
                 confidence: 0.92,

--- a/rust/datefinder-kernel/src/lib.rs
+++ b/rust/datefinder-kernel/src/lib.rs
@@ -611,7 +611,8 @@ fn resolve_offset(
     reference: DateTime<FixedOffset>,
     delta_seconds: i64,
 ) -> Option<DateTime<FixedOffset>> {
-    let resolved = reference.checked_add_signed(Duration::seconds(delta_seconds))?;
+    let duration = Duration::try_seconds(delta_seconds)?;
+    let resolved = reference.checked_add_signed(duration)?;
     // Python datetime.fromisoformat only accepts years 1..9999.
     if !(1..=9999).contains(&resolved.year()) {
         return None;
@@ -1490,7 +1491,10 @@ fn parse_raw(
             let Some(days) = relative_word_days(all.as_str()) else {
                 continue;
             };
-            let Some(resolved) = resolve_offset(reference, days.saturating_mul(86_400)) else {
+            let Some(delta_seconds) = days.checked_mul(86_400) else {
+                continue;
+            };
+            let Some(resolved) = resolve_offset(reference, delta_seconds) else {
                 continue;
             };
             out.push(RawMatch {

--- a/rust/datefinder-kernel/src/lib.rs
+++ b/rust/datefinder-kernel/src/lib.rs
@@ -606,6 +606,19 @@ fn unit_seconds(unit: &str) -> Option<i64> {
     }
 }
 
+/// Skip unresolvable relative offsets instead of panicking on chrono overflow.
+fn resolve_offset(
+    reference: DateTime<FixedOffset>,
+    delta_seconds: i64,
+) -> Option<DateTime<FixedOffset>> {
+    let resolved = reference.checked_add_signed(Duration::seconds(delta_seconds))?;
+    // Python datetime.fromisoformat only accepts years 1..9999.
+    if !(1..=9999).contains(&resolved.year()) {
+        return None;
+    }
+    Some(resolved)
+}
+
 fn parse_reference(reference_dt: Option<&str>) -> DateTime<FixedOffset> {
     if let Some(raw) = reference_dt {
         if let Ok(dt) = DateTime::parse_from_rfc3339(raw) {
@@ -1477,7 +1490,9 @@ fn parse_raw(
             let Some(days) = relative_word_days(all.as_str()) else {
                 continue;
             };
-            let resolved = reference + Duration::days(days);
+            let Some(resolved) = resolve_offset(reference, days.saturating_mul(86_400)) else {
+                continue;
+            };
             out.push(RawMatch {
                 kind: "relative",
                 text: all.as_str().to_string(),
@@ -1526,7 +1541,9 @@ fn parse_raw(
                 }
                 -d
             };
-            let resolved = reference + Duration::days(delta_days);
+            let Some(resolved) = resolve_offset(reference, delta_days.saturating_mul(86_400)) else {
+                continue;
+            };
             out.push(RawMatch {
                 kind: "relative",
                 text: all.as_str().to_string(),
@@ -1554,8 +1571,12 @@ fn parse_raw(
             let Some(unit_s) = unit_seconds(&caps["unit"]) else {
                 continue;
             };
-            let delta = num * unit_s;
-            let resolved = reference + Duration::seconds(delta);
+            let Some(delta) = num.checked_mul(unit_s) else {
+                continue;
+            };
+            let Some(resolved) = resolve_offset(reference, delta) else {
+                continue;
+            };
             out.push(RawMatch {
                 kind: "relative",
                 text: all.as_str().to_string(),
@@ -1583,8 +1604,12 @@ fn parse_raw(
             let Some(unit_s) = unit_seconds(&caps["unit"]) else {
                 continue;
             };
-            let delta = -(num * unit_s);
-            let resolved = reference + Duration::seconds(delta);
+            let Some(delta) = num.checked_mul(unit_s).and_then(|d| d.checked_neg()) else {
+                continue;
+            };
+            let Some(resolved) = resolve_offset(reference, delta) else {
+                continue;
+            };
             out.push(RawMatch {
                 kind: "relative",
                 text: all.as_str().to_string(),
@@ -1618,7 +1643,9 @@ fn parse_raw(
             let Some(unit_s) = unit_seconds(&caps["unit"]) else {
                 continue;
             };
-            let total = num * unit_s;
+            let Some(total) = num.checked_mul(unit_s) else {
+                continue;
+            };
             let mut components = HashMap::new();
             components.insert(caps["unit"].to_lowercase(), num);
             out.push(RawMatch {

--- a/rust/datefinder-kernel/src/lib.rs
+++ b/rust/datefinder-kernel/src/lib.rs
@@ -1574,7 +1574,9 @@ fn parse_raw(
                 Some(m) => m,
                 None => continue,
             };
-            let num: i64 = caps["num"].parse().unwrap_or_default();
+            let Ok(num) = caps["num"].parse::<i64>() else {
+                continue;
+            };
             let Some(unit_s) = unit_seconds(&caps["unit"]) else {
                 continue;
             };
@@ -1607,7 +1609,9 @@ fn parse_raw(
                 Some(m) => m,
                 None => continue,
             };
-            let num: i64 = caps["num"].parse().unwrap_or_default();
+            let Ok(num) = caps["num"].parse::<i64>() else {
+                continue;
+            };
             let Some(unit_s) = unit_seconds(&caps["unit"]) else {
                 continue;
             };
@@ -1646,7 +1650,9 @@ fn parse_raw(
             {
                 continue;
             }
-            let num: i64 = caps["num"].parse().unwrap_or_default();
+            let Ok(num) = caps["num"].parse::<i64>() else {
+                continue;
+            };
             let Some(unit_s) = unit_seconds(&caps["unit"]) else {
                 continue;
             };

--- a/rust/datefinder-kernel/src/lib.rs
+++ b/rust/datefinder-kernel/src/lib.rs
@@ -1545,7 +1545,10 @@ fn parse_raw(
                 }
                 -d
             };
-            let Some(resolved) = resolve_offset(reference, delta_days.saturating_mul(86_400)) else {
+            let Some(delta_seconds) = delta_days.checked_mul(86_400) else {
+                continue;
+            };
+            let Some(resolved) = resolve_offset(reference, delta_seconds) else {
                 continue;
             };
             out.push(RawMatch {
@@ -1557,7 +1560,7 @@ fn parse_raw(
                 grain: "day",
                 value: RawValue::Relative {
                     resolved_datetime: resolved.to_rfc3339(),
-                    delta_seconds: delta_days * 86_400,
+                    delta_seconds,
                     anchor: "reference".to_string(),
                 },
                 confidence: 0.90,

--- a/tests/test_v2_extract.py
+++ b/tests/test_v2_extract.py
@@ -297,6 +297,8 @@ def test_relative_delta_overflow_skips_unresolvable():
     assert list(datefinder.find_dates("in 999999999999 weeks", base_date=ref)) == []
     assert list(datefinder.find_dates("in 292471209 years", base_date=ref)) == []
     assert list(datefinder.find_dates("292471209 years ago", base_date=ref)) == []
+    # Digits that do not fit in i64 must not parse as 0 (false reference hit).
+    assert list(datefinder.find_dates("in 99999999999999999999 years", base_date=ref)) == []
     assert list(datefinder.find_dates("in 3 days", base_date=ref)) == [
         datetime(2026, 3, 22, 12, 0, tzinfo=timezone.utc)
     ]

--- a/tests/test_v2_extract.py
+++ b/tests/test_v2_extract.py
@@ -291,6 +291,10 @@ def test_relative_delta_overflow_skips_unresolvable():
     assert list(datefinder.find_dates("in 292000 years", base_date=ref)) == []
     assert list(datefinder.find_dates("in 10000 years", base_date=ref)) == []
     assert list(datefinder.find_dates("1000000000000000 years ago", base_date=ref)) == []
+    # Seconds product fits in i64 but exceeds TimeDelta::seconds bounds.
+    assert list(datefinder.find_dates("in 999999999999 days", base_date=ref)) == []
+    assert list(datefinder.find_dates("999999999999 days ago", base_date=ref)) == []
+    assert list(datefinder.find_dates("in 999999999999 weeks", base_date=ref)) == []
     assert list(datefinder.find_dates("in 3 days", base_date=ref)) == [
         datetime(2026, 3, 22, 12, 0, tzinfo=timezone.utc)
     ]

--- a/tests/test_v2_extract.py
+++ b/tests/test_v2_extract.py
@@ -283,3 +283,14 @@ def test_issue_84_allow_multiline_flag_controls_cross_line_extraction():
         )
         == []
     )
+
+
+def test_relative_delta_overflow_skips_unresolvable():
+    ref = datetime(2026, 3, 19, 12, 0, tzinfo=timezone.utc)
+    # Chrono panics / Python fromisoformat rejects these without a checked resolve.
+    assert list(datefinder.find_dates("in 292000 years", base_date=ref)) == []
+    assert list(datefinder.find_dates("in 10000 years", base_date=ref)) == []
+    assert list(datefinder.find_dates("1000000000000000 years ago", base_date=ref)) == []
+    assert list(datefinder.find_dates("in 3 days", base_date=ref)) == [
+        datetime(2026, 3, 22, 12, 0, tzinfo=timezone.utc)
+    ]

--- a/tests/test_v2_extract.py
+++ b/tests/test_v2_extract.py
@@ -295,6 +295,8 @@ def test_relative_delta_overflow_skips_unresolvable():
     assert list(datefinder.find_dates("in 999999999999 days", base_date=ref)) == []
     assert list(datefinder.find_dates("999999999999 days ago", base_date=ref)) == []
     assert list(datefinder.find_dates("in 999999999999 weeks", base_date=ref)) == []
+    assert list(datefinder.find_dates("in 292471209 years", base_date=ref)) == []
+    assert list(datefinder.find_dates("292471209 years ago", base_date=ref)) == []
     assert list(datefinder.find_dates("in 3 days", base_date=ref)) == [
         datetime(2026, 3, 22, 12, 0, tzinfo=timezone.utc)
     ]


### PR DESCRIPTION
extract/find_dates hits PanicException when in 999999999999 days. This PR fixes the regression with a focused test covering the case.
